### PR TITLE
Fix code highlighting in `Result.Extra.toTask` docs 🐞

### DIFF
--- a/src/Result/Extra.elm
+++ b/src/Result/Extra.elm
@@ -492,9 +492,9 @@ This can be helpful when the value of a succeeding Task needs to be decoded, but
 a failure to decode should result in a failing `Task`, not a succeeding Task
 containing a `Result.Err`:
 
-andThenDecode : (a -> Result x b) -> Task x a -> Task x b
-andThenDecode decode =
-Task.andThen (decode >> Result.Extra.toTask)
+    andThenDecode : (a -> Result x b) -> Task x a -> Task x b
+    andThenDecode decode =
+        Task.andThen (decode >> Result.Extra.toTask)
 
 -}
 toTask : Result x a -> Task x a


### PR DESCRIPTION
Hi, first of all huge THANKS for this community effort! 🙌🏻 

I'd like to start putting my grain of salt by fixing this in the docs:

<img width="675" alt="Screenshot 2024-02-28 at 11 22 42" src="https://github.com/elmcraft/core-extra/assets/5127501/8cf386c6-b58d-44a6-a27f-d7b573a061f9">
