### PR TITLE
Add warning message to List.Extra (suggested by elmcraft/core-extra#44)

### DIFF
--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -62,6 +62,8 @@ module List.Extra exposing
 
 # Split to groups of given size
 
+> Note that (due to their usage of `List.take` from _elm/core_) the following functions are not always **strictly tail recursive**. For some large tasks it is possible you may run into runtime errors by exceeding the maximum call stack size. For help in this look [here](https://github.com/elmcraft/core-extra.git) and [here](https://github.com/elmcraft/core-extra.git).
+
 @docs groupsOf, groupsOfWithStep, groupsOfVarying, greedyGroupsOf, greedyGroupsOfWithStep
 
 

--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -62,7 +62,7 @@ module List.Extra exposing
 
 # Split to groups of given size
 
-> Note that (due to their usage of `List.take` from _elm/core_) the following functions are not always **strictly tail recursive**. For some large tasks it is possible you may run into runtime errors by exceeding the maximum call stack size. For help in this look [here](https://github.com/elmcraft/core-extra.git) and [here](https://github.com/elmcraft/core-extra.git).
+> Note that (due to their usage of `List.take` from _elm/core_) the following functions are not always **strictly tail recursive**. For some large tasks it is possible you may run into runtime errors by exceeding the maximum call stack size. For help in this look [here](https://github.com/elm-community/list-extra/issues/164) and [here](https://github.com/billstclair/elm-crypto-string/issues/10).
 
 @docs groupsOf, groupsOfWithStep, groupsOfVarying, greedyGroupsOf, greedyGroupsOfWithStep
 


### PR DESCRIPTION
Add warning message for `groupsOf...` functions in the documentation in `List.Extra` as suggested in https://github.com/elmcraft/core-extra/issues/44#issuecomment-1968594245