### PR TITLE
Inline call to `Result.map` in `Result.Extra.andMap` for performance

### DIFF
--- a/benchmarks/src/Benchmarks.elm
+++ b/benchmarks/src/Benchmarks.elm
@@ -317,16 +317,25 @@ resultExtra =
             (\andMap -> Ok negate |> andMap (Ok 0))
             [ ( "original", Result.Extra.AndMap.andMapOriginal )
             , ( "inlined", Result.Extra.AndMap.andMapInlined )
+            , ( "inlined, nested case-of", Result.Extra.AndMap.andMapInlinedNestedCaseOf )
             ]
         , rank "andMap - Err × Ok"
             (\andMap -> Err "e" |> andMap (Ok 0))
             [ ( "original", Result.Extra.AndMap.andMapOriginal )
             , ( "inlined", Result.Extra.AndMap.andMapInlined )
+            , ( "inlined, nested case-of", Result.Extra.AndMap.andMapInlinedNestedCaseOf )
             ]
         , rank "andMap - Ok × Err"
             (\andMap -> Ok negate |> andMap (Err "e"))
             [ ( "original", Result.Extra.AndMap.andMapOriginal )
             , ( "inlined", Result.Extra.AndMap.andMapInlined )
+            , ( "inlined, nested case-of", Result.Extra.AndMap.andMapInlinedNestedCaseOf )
+            ]
+        , rank "andMap - Err × Err"
+            (\andMap -> Err "b" |> andMap (Err "e"))
+            [ ( "original", Result.Extra.AndMap.andMapOriginal )
+            , ( "inlined", Result.Extra.AndMap.andMapInlined )
+            , ( "inlined, nested case-of", Result.Extra.AndMap.andMapInlinedNestedCaseOf )
             ]
         , rank "andMap - Err × Err"
             (\andMap -> Err "l" |> andMap (Err "e"))

--- a/benchmarks/src/Benchmarks.elm
+++ b/benchmarks/src/Benchmarks.elm
@@ -23,6 +23,7 @@ import List.Extra.NotMember
 import List.Extra.Unfoldr
 import List.Extra.UniquePairs
 import Maybe.Extra.AndMap
+import Result.Extra.AndMap
 import Set exposing (Set)
 import Set.Extra.AreDisjoint
 import Set.Extra.SymmetricDifference
@@ -40,6 +41,7 @@ main =
         , setExtra
         , stringExtra
         , maybeExtra
+        , resultExtra
         ]
         |> BenchmarkRunner.program
 
@@ -304,6 +306,32 @@ maybeExtra =
             , ( "simplified", Maybe.Extra.AndMap.andMapSimplified )
             , ( "nested case-of", Maybe.Extra.AndMap.andMapNestedCaseOf )
             , ( "nested case-of ignoring Nothing", Maybe.Extra.AndMap.andMapNestedCaseOfIgnoringNothing )
+            ]
+        ]
+
+
+resultExtra : Benchmark
+resultExtra =
+    describe "Result.Extra"
+        [ rank "andMap - Ok × Ok"
+            (\andMap -> Ok negate |> andMap (Ok 0))
+            [ ( "original", Result.Extra.AndMap.andMapOriginal )
+            , ( "inlined", Result.Extra.AndMap.andMapInlined )
+            ]
+        , rank "andMap - Err × Ok"
+            (\andMap -> Err "e" |> andMap (Ok 0))
+            [ ( "original", Result.Extra.AndMap.andMapOriginal )
+            , ( "inlined", Result.Extra.AndMap.andMapInlined )
+            ]
+        , rank "andMap - Ok × Err"
+            (\andMap -> Ok negate |> andMap (Err "e"))
+            [ ( "original", Result.Extra.AndMap.andMapOriginal )
+            , ( "inlined", Result.Extra.AndMap.andMapInlined )
+            ]
+        , rank "andMap - Err × Err"
+            (\andMap -> Err "l" |> andMap (Err "e"))
+            [ ( "original", Result.Extra.AndMap.andMapOriginal )
+            , ( "inlined", Result.Extra.AndMap.andMapInlined )
             ]
         ]
 

--- a/benchmarks/src/Result/Extra/AndMap.elm
+++ b/benchmarks/src/Result/Extra/AndMap.elm
@@ -1,4 +1,4 @@
-module Result.Extra.AndMap exposing (andMapInlined, andMapOriginal)
+module Result.Extra.AndMap exposing (andMapInlined, andMapInlinedNestedCaseOf, andMapOriginal)
 
 
 andMapOriginal : Result e a -> Result e (a -> b) -> Result e b
@@ -21,4 +21,19 @@ andMapInlined ra rb =
             Err x
 
         ( Err x, _ ) ->
+            Err x
+
+
+andMapInlinedNestedCaseOf : Result e a -> Result e (a -> b) -> Result e b
+andMapInlinedNestedCaseOf ra rb =
+    case ra of
+        Ok o ->
+            case rb of
+                Ok fn ->
+                    Ok (fn o)
+
+                Err x ->
+                    Err x
+
+        Err x ->
             Err x

--- a/benchmarks/src/Result/Extra/AndMap.elm
+++ b/benchmarks/src/Result/Extra/AndMap.elm
@@ -1,0 +1,24 @@
+module Result.Extra.AndMap exposing (andMapInlined, andMapOriginal)
+
+
+andMapOriginal : Result e a -> Result e (a -> b) -> Result e b
+andMapOriginal ra rb =
+    case ( ra, rb ) of
+        ( _, Err x ) ->
+            Err x
+
+        ( o, Ok fn ) ->
+            Result.map fn o
+
+
+andMapInlined : Result e a -> Result e (a -> b) -> Result e b
+andMapInlined ra rb =
+    case ( ra, rb ) of
+        ( Ok o, Ok fn ) ->
+            Ok (fn o)
+
+        ( Err x, _ ) ->
+            Err x
+
+        ( _, Err x ) ->
+            Err x

--- a/benchmarks/src/Result/Extra/AndMap.elm
+++ b/benchmarks/src/Result/Extra/AndMap.elm
@@ -17,8 +17,8 @@ andMapInlined ra rb =
         ( Ok o, Ok fn ) ->
             Ok (fn o)
 
-        ( Err x, _ ) ->
+        ( _, Err x ) ->
             Err x
 
-        ( _, Err x ) ->
+        ( Err x, _ ) ->
             Err x


### PR DESCRIPTION
This inlines the call to `Result.map` in `Result.Extra.andMap`, because we're already pattern matching on the values, might as well do it completely and save a function call.

The performance improvements are minor, but the code size increase is also minor, so it's a tradeoff. I picked this function in particular because it's the one we use the most at work.

## Benchmarks
Firefox
![image](https://github.com/user-attachments/assets/3f464003-e88a-4000-b9c3-ad6ee5a8fa0a)
Chrome
![image](https://github.com/user-attachments/assets/0154edc2-4ea0-4552-a389-7db84f83c6bd)