### PR TITLE
Faster `Maybe.Extra.andMap`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ elm-stuff/
 node_modules
 tests/VerifyExamples
 .DS_Store
+benchmarks/index.html

--- a/benchmarks/src/Benchmarks.elm
+++ b/benchmarks/src/Benchmarks.elm
@@ -262,16 +262,19 @@ maybeExtra =
             (\andMap -> Just negate |> andMap (Just 0))
             [ ( "original", Maybe.Extra.AndMap.andMapOriginal )
             , ( "inlined", Maybe.Extra.AndMap.andMapInlined )
+, ( "simplified", Maybe.Extra.AndMap.andMapSimplified )
             ]
         , rank "andMap - Nothing × Just"
             (\andMap -> Nothing |> andMap (Just 0))
             [ ( "original", Maybe.Extra.AndMap.andMapOriginal )
             , ( "inlined", Maybe.Extra.AndMap.andMapInlined )
+, ( "simplified", Maybe.Extra.AndMap.andMapSimplified )
             ]
         , rank "andMap - Just × Nothing"
             (\andMap -> Just negate |> andMap Nothing)
             [ ( "original", Maybe.Extra.AndMap.andMapOriginal )
             , ( "inlined", Maybe.Extra.AndMap.andMapInlined )
+, ( "simplified", Maybe.Extra.AndMap.andMapSimplified )
             ]
         ]
 

--- a/benchmarks/src/Benchmarks.elm
+++ b/benchmarks/src/Benchmarks.elm
@@ -22,6 +22,7 @@ import List.Extra.GroupsOf
 import List.Extra.Lift
 import List.Extra.Unfoldr
 import List.Extra.UniquePairs
+import Maybe.Extra.AndMap
 import Set exposing (Set)
 import Set.Extra.AreDisjoint
 import Set.Extra.SymmetricDifference
@@ -38,6 +39,7 @@ main =
         , tupleExtra
         , setExtra
         , stringExtra
+        , maybeExtra
         ]
         |> BenchmarkRunner.program
 
@@ -250,6 +252,27 @@ stringExtra : Benchmark
 stringExtra =
     describe "String.Extra"
         [ stringExtraIsBlank
+        ]
+
+
+maybeExtra : Benchmark
+maybeExtra =
+    describe "Maybe.Extra"
+        [ rank "andMap - Just × Just"
+            (\andMap -> Just negate |> andMap (Just 0))
+            [ ( "original", Maybe.Extra.AndMap.andMapOriginal )
+            , ( "inlined", Maybe.Extra.AndMap.andMapInlined )
+            ]
+        , rank "andMap - Nothing × Just"
+            (\andMap -> Nothing |> andMap (Just 0))
+            [ ( "original", Maybe.Extra.AndMap.andMapOriginal )
+            , ( "inlined", Maybe.Extra.AndMap.andMapInlined )
+            ]
+        , rank "andMap - Just × Nothing"
+            (\andMap -> Just negate |> andMap Nothing)
+            [ ( "original", Maybe.Extra.AndMap.andMapOriginal )
+            , ( "inlined", Maybe.Extra.AndMap.andMapInlined )
+            ]
         ]
 
 

--- a/benchmarks/src/Benchmarks.elm
+++ b/benchmarks/src/Benchmarks.elm
@@ -262,19 +262,33 @@ maybeExtra =
             (\andMap -> Just negate |> andMap (Just 0))
             [ ( "original", Maybe.Extra.AndMap.andMapOriginal )
             , ( "inlined", Maybe.Extra.AndMap.andMapInlined )
-, ( "simplified", Maybe.Extra.AndMap.andMapSimplified )
+            , ( "simplified", Maybe.Extra.AndMap.andMapSimplified )
+            , ( "nested case-of", Maybe.Extra.AndMap.andMapNestedCaseOf )
+            , ( "nested case-of ignoring Nothing", Maybe.Extra.AndMap.andMapNestedCaseOfIgnoringNothing )
             ]
         , rank "andMap - Nothing × Just"
             (\andMap -> Nothing |> andMap (Just 0))
             [ ( "original", Maybe.Extra.AndMap.andMapOriginal )
             , ( "inlined", Maybe.Extra.AndMap.andMapInlined )
-, ( "simplified", Maybe.Extra.AndMap.andMapSimplified )
+            , ( "simplified", Maybe.Extra.AndMap.andMapSimplified )
+            , ( "nested case-of", Maybe.Extra.AndMap.andMapNestedCaseOf )
+            , ( "nested case-of ignoring Nothing", Maybe.Extra.AndMap.andMapNestedCaseOfIgnoringNothing )
             ]
         , rank "andMap - Just × Nothing"
             (\andMap -> Just negate |> andMap Nothing)
             [ ( "original", Maybe.Extra.AndMap.andMapOriginal )
             , ( "inlined", Maybe.Extra.AndMap.andMapInlined )
-, ( "simplified", Maybe.Extra.AndMap.andMapSimplified )
+            , ( "simplified", Maybe.Extra.AndMap.andMapSimplified )
+            , ( "nested case-of", Maybe.Extra.AndMap.andMapNestedCaseOf )
+            , ( "nested case-of ignoring Nothing", Maybe.Extra.AndMap.andMapNestedCaseOfIgnoringNothing )
+            ]
+        , rank "andMap - Nothing × Nothing"
+            (\andMap -> Nothing |> andMap Nothing)
+            [ ( "original", Maybe.Extra.AndMap.andMapOriginal )
+            , ( "inlined", Maybe.Extra.AndMap.andMapInlined )
+            , ( "simplified", Maybe.Extra.AndMap.andMapSimplified )
+            , ( "nested case-of", Maybe.Extra.AndMap.andMapNestedCaseOf )
+            , ( "nested case-of ignoring Nothing", Maybe.Extra.AndMap.andMapNestedCaseOfIgnoringNothing )
             ]
         ]
 

--- a/benchmarks/src/Maybe/Extra/AndMap.elm
+++ b/benchmarks/src/Maybe/Extra/AndMap.elm
@@ -17,3 +17,13 @@ andMapInlined ra rb =
 
         ( Nothing, _ ) ->
             Nothing
+
+
+andMapSimplified : Maybe a -> Maybe (a -> b) -> Maybe b
+andMapSimplified ra rb =
+    case ( ra, rb ) of
+        ( Just o, Just fn ) ->
+            Just (fn o)
+
+        _ ->
+            Nothing

--- a/benchmarks/src/Maybe/Extra/AndMap.elm
+++ b/benchmarks/src/Maybe/Extra/AndMap.elm
@@ -27,3 +27,31 @@ andMapSimplified ra rb =
 
         _ ->
             Nothing
+
+andMapNestedCaseOfIgnoringNothing : Maybe a -> Maybe (a -> b) -> Maybe b
+andMapNestedCaseOfIgnoringNothing ra rb =
+    case ra of
+        Just o ->
+            case rb of
+                Just fn ->
+                    Just (fn o)
+
+                _ ->
+                    Nothing
+
+        _ ->
+            Nothing
+
+andMapNestedCaseOf : Maybe a -> Maybe (a -> b) -> Maybe b
+andMapNestedCaseOf ra rb =
+    case ra of
+        Just o ->
+            case rb of
+                Just fn ->
+                    Just (fn o)
+
+                Nothing ->
+                    Nothing
+
+        Nothing ->
+            Nothing

--- a/benchmarks/src/Maybe/Extra/AndMap.elm
+++ b/benchmarks/src/Maybe/Extra/AndMap.elm
@@ -28,6 +28,7 @@ andMapSimplified ra rb =
         _ ->
             Nothing
 
+
 andMapNestedCaseOfIgnoringNothing : Maybe a -> Maybe (a -> b) -> Maybe b
 andMapNestedCaseOfIgnoringNothing ra rb =
     case ra of
@@ -41,6 +42,7 @@ andMapNestedCaseOfIgnoringNothing ra rb =
 
         _ ->
             Nothing
+
 
 andMapNestedCaseOf : Maybe a -> Maybe (a -> b) -> Maybe b
 andMapNestedCaseOf ra rb =

--- a/benchmarks/src/Maybe/Extra/AndMap.elm
+++ b/benchmarks/src/Maybe/Extra/AndMap.elm
@@ -1,0 +1,19 @@
+module Maybe.Extra.AndMap exposing (..)
+
+
+andMapOriginal : Maybe a -> Maybe (a -> b) -> Maybe b
+andMapOriginal =
+    Maybe.map2 (|>)
+
+
+andMapInlined : Maybe a -> Maybe (a -> b) -> Maybe b
+andMapInlined ra rb =
+    case ( ra, rb ) of
+        ( Just o, Just fn ) ->
+            Just (fn o)
+
+        ( _, Nothing ) ->
+            Nothing
+
+        ( Nothing, _ ) ->
+            Nothing

--- a/src/Maybe/Extra.elm
+++ b/src/Maybe/Extra.elm
@@ -801,8 +801,16 @@ Advanced functional programmers will recognize this as the implementation of `<*
 
 -}
 andMap : Maybe a -> Maybe (a -> b) -> Maybe b
-andMap =
-    Maybe.map2 (|>)
+andMap ma mb =
+    case ( ma, mb ) of
+        ( Just o, Just fn ) ->
+            Just (fn o)
+
+        ( _, Nothing ) ->
+            Nothing
+
+        ( Nothing, _ ) ->
+            Nothing
 
 
 {-| Take two `Maybe` values. If the first one equals `Nothing`, return `Nothing`. Otherwise return the second value.

--- a/src/Maybe/Extra.elm
+++ b/src/Maybe/Extra.elm
@@ -802,11 +802,16 @@ Advanced functional programmers will recognize this as the implementation of `<*
 -}
 andMap : Maybe a -> Maybe (a -> b) -> Maybe b
 andMap ma mb =
-    case ( ma, mb ) of
-        ( Just o, Just fn ) ->
-            Just (fn o)
+    case ma of
+        Just o ->
+            case mb of
+                Just fn ->
+                    Just (fn o)
 
-        _ ->
+                Nothing ->
+                    Nothing
+
+        Nothing ->
             Nothing
 
 

--- a/src/Maybe/Extra.elm
+++ b/src/Maybe/Extra.elm
@@ -806,10 +806,7 @@ andMap ma mb =
         ( Just o, Just fn ) ->
             Just (fn o)
 
-        ( _, Nothing ) ->
-            Nothing
-
-        ( Nothing, _ ) ->
+        _ ->
             Nothing
 
 


### PR DESCRIPTION
The old implementation is significantly slower in Firefox and _massively_ slower in Chrome.

Firefox
![image](https://github.com/user-attachments/assets/37e98918-7338-408a-bb2c-0485d12a686c)
Chrome
![image](https://github.com/user-attachments/assets/64a857a4-cdf6-4faa-b393-dc4d8c896189)
