### PR TITLE
Simplify List.Extra.notMember

### DIFF
--- a/benchmarks/src/Benchmarks.elm
+++ b/benchmarks/src/Benchmarks.elm
@@ -17,9 +17,9 @@ import Array.Extra.Unzip
 import Benchmark exposing (Benchmark, describe)
 import Benchmark.Alternative exposing (rank)
 import Benchmark.Runner.Alternative as BenchmarkRunner
-import List.Extra
 import List.Extra.GroupsOf
 import List.Extra.Lift
+import List.Extra.NotMember
 import List.Extra.Unfoldr
 import List.Extra.UniquePairs
 import Maybe.Extra.AndMap
@@ -213,6 +213,21 @@ listExtra =
             (\lift4 -> lift4 (\a b c d -> a + b + c + d) shortList shortList shortList shortList)
             [ ( "original", List.Extra.Lift.liftAndThen4 )
             , ( "foldl", List.Extra.Lift.liftFold4 )
+            ]
+         , rank "notMember 1"
+            (\notMember -> notMember 1 intList)
+            [ ( "Original", List.Extra.NotMember.notMemberOriginal )
+            , ( "Simplified", List.Extra.NotMember.notMemberSimple )
+            ]
+         , rank "notMember 99"
+            (\notMember -> notMember 99 intList)
+            [ ( "Original", List.Extra.NotMember.notMemberOriginal )
+            , ( "Simplified", List.Extra.NotMember.notMemberSimple )
+            ]
+         , rank "notMember 101"
+            (\notMember -> notMember 101 intList)
+            [ ( "Original", List.Extra.NotMember.notMemberOriginal )
+            , ( "Simplified", List.Extra.NotMember.notMemberSimple )
             ]
          ]
             ++ List.concatMap toComparisonsGroupsOfWithStep (List.range 1 4)

--- a/benchmarks/src/List/Extra/NotMember.elm
+++ b/benchmarks/src/List/Extra/NotMember.elm
@@ -1,0 +1,11 @@
+module List.Extra.NotMember exposing (notMemberOriginal, notMemberSimple)
+
+
+notMemberOriginal : a -> List a -> Bool
+notMemberOriginal x =
+    not << List.member x
+
+
+notMemberSimple : a -> List a -> Bool
+notMemberSimple x list =
+    not (List.member x list)

--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -589,8 +589,8 @@ reverseMap f xs =
 
 -}
 notMember : a -> List a -> Bool
-notMember x =
-    not << List.member x
+notMember x list =
+    not (List.member x list)
 
 
 {-| Find the first element that satisfies a predicate and return


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/66a46948-6f3a-47a4-806b-0423f442b40e)

![image](https://github.com/user-attachments/assets/0825015e-d59f-4c31-929d-2619ba6b1ff4)

~I intend to create PRs for all uses of `<<`/`>>`, do we need benchmarks for all of them? I expect the results to always look like this.~ Yes. We need benchmarks.