### PR TITLE
Fixed: Test Dependency on elm/random

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -27,6 +27,7 @@
     },
     "test-dependencies": {
         "elm/html": "1.0.0 <= v < 2.0.0",
-        "elm-explorations/test": "2.0.0 <= v < 3.0.0"
+        "elm-explorations/test": "2.0.0 <= v < 3.0.0",
+        "elm/random": "1.0.0 <= v < 2.0.0"
     }
 }


### PR DESCRIPTION
Running `elm-test-rs` on the test suite flagged an issue with the tests missing the `elm/random` dependency.

Random is imported in `tests/ArrayTests.elm`, but not listed in the test-dependenceies section of the elm.json.

I'm not sure how the regular tests are passing without this import, as it doesn't even seem to be a transient dependency. It might be that because `elm/random` is a dependency of `elm-test` itself, it doesn't flag it? 

Anyway, it seems that both testing tools work with this change.